### PR TITLE
[ENH]: Remove blankline doctest with an argument

### DIFF
--- a/npdoc_to_md/docs/Home.md
+++ b/npdoc_to_md/docs/Home.md
@@ -22,6 +22,8 @@ JSON dictionnary decorated by {} with the following keys (see examples below):
     See https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code-and-syntax-highlighting
     If not provided outputs are encapsulated by ````python```` to create a markdown Python code block. You can use any flavor
     you please or the special flag "raw" which will be a code block without flavor. If you choose "markdown" there is no encapsulation.
+* <i>(optional)</i> "remove_doctest_blanklines": If True (default), replaces "<BLANKLINE>" used for doctest with an empty string.
+    See https://docs.python.org/3.8/library/doctest.html#how-are-docstring-examples-recognized
 
 ### Examples
 

--- a/npdoc_to_md/helpers.py
+++ b/npdoc_to_md/helpers.py
@@ -266,7 +266,7 @@ class ExampleParser():
         outputs = dict(zip(outputs,outputs_flavors))
         return outputs
 
-    def to_md_lines(self):
+    def to_md_lines(self, remove_doctest_blanklines=True):
         """
         Converts the lines provided at class instantiation
         to markdown lines.
@@ -350,7 +350,7 @@ class ExampleParser():
             return False
 
         # go over the lines and compare previous and next lines when available
-        for ix, line in enumerate(lines): 
+        for ix, line in enumerate(lines):
             previous_line = lines[ix-1] if ix != 0 else None
             next_line = lines[ix+1] if ix < len(lines) - 1 else None
 
@@ -388,13 +388,21 @@ class ExampleParser():
                 flavor = get_flavor_of_output(ix)
                 if flavor != 'markdown':
                     md_example_section.append('```')
+
+        # remove <BLANKLINE> used for doctest if so desired
+        # do this here to not break the logic above since we compare
+        # each line with its previous and next line
+        if remove_doctest_blanklines:
+            md_example_section = ['' if l == '<BLANKLINE>' else l for l in md_example_section]
         return md_example_section
 
 
 # # Function to convert numpydoc sections to markdown
 
 def numpydoc_section_to_md_lines(numpydoc_obj, section_name, 
-                                 examples_md_flavor='python', md_section_level='####'):
+                                 examples_md_flavor='python',
+                                 md_section_level='####',
+                                 remove_doctest_blanklines=True):
     """
     Converts a section of a numpydoc object (see Parameters)
     to lines of markdown strings.
@@ -537,7 +545,7 @@ def numpydoc_section_to_md_lines(numpydoc_obj, section_name,
     # very special case "Examples" section
     elif section_name == 'Examples':
         ex = ExampleParser(lines=section, examples_md_flavor=examples_md_flavor)
-        lines.extend(ex.to_md_lines())
+        lines.extend(ex.to_md_lines(remove_doctest_blanklines=remove_doctest_blanklines))
 
     # FINALIZE
     # add an empty line at the end of the section

--- a/npdoc_to_md/testing.py
+++ b/npdoc_to_md/testing.py
@@ -129,6 +129,25 @@ def example_func3():
     pass
 
 
+# # Fourth example
+#
+# With a blankline in the examples
+
+def example_func4():
+    """
+    Function to test if we can successfully remove doctest blanklines.
+    See https://docs.python.org/3.8/library/doctest.html#how-are-docstring-examples-recognized
+
+    Examples
+    --------
+    >>> example_func4()
+    <BLANKLINE>
+    foo
+    """
+    print('')
+    print('foo')
+
+
 # # Classes
 
 class ExampleClass():

--- a/npdoc_to_md/tests/test_content.py
+++ b/npdoc_to_md/tests/test_content.py
@@ -2,6 +2,7 @@
 from npdoc_to_md.testing import (example_func,
                                  example_func2,
                                  example_func3,
+                                 example_func4,
                                  ExampleClass)
 
 from npdoc_to_md import render_md_from_obj_docstring
@@ -136,3 +137,34 @@ ex = ExampleClass('john', 'doe')
 def test_rendering(func, func_name, expected_md):
     md = render_md_from_obj_docstring(func, func_name)
     assert md == expected_md
+
+
+# # Test blankline removal
+
+# +
+with_blankline = """**<span style="color:purple">example&#95;func4</span>_()_**
+
+
+Function to test if we can successfully remove doctest blanklines.
+See https://docs.python.org/3.8/library/doctest.html#how-are-docstring-examples-recognized
+
+
+#### Examples
+```python
+example_func4()
+```
+```
+<BLANKLINE>
+foo
+```"""
+
+without_blankline = '\n'.join('' if l == '<BLANKLINE>' else l for l in with_blankline.split('\n'))
+
+
+def test_doctest_blankline_present():
+    md = render_md_from_obj_docstring(example_func4, 'example_func4', remove_doctest_blanklines=False, examples_md_flavor='raw')
+    assert md == with_blankline
+
+def test_doctest_blankline_absent():
+    md = render_md_from_obj_docstring(example_func4, 'example_func4', remove_doctest_blanklines=True, examples_md_flavor='raw')
+    assert md == without_blankline


### PR DESCRIPTION
This PR provides the ability to remove <code>\<BLANKLINE\></code> used for doctest with an argument in the all main functions of <code>npdoc_to_md</code> (except <code>render_md_file</code>). See https://docs.python.org/3.8/library/doctest.html#how-are-docstring-examples-recognized

It is activated by default (as its presence could compromise the proper rendering of docstring examples).